### PR TITLE
Cookies

### DIFF
--- a/Vue/graf/src/components/Graf.vue
+++ b/Vue/graf/src/components/Graf.vue
@@ -60,6 +60,7 @@ import Toolbar from '../components/Toolbar.vue'
 import GrafTools from '../middleware/grafTools.js'
 import PathTools from '../middleware/pathTools.js'
 import helperFunctions from '../middleware/helperFunctions';
+import cookieHelpers from "..middleware/cookieHelper.js";
 //import Help from "../components/Help.vue";
 //import About from 'About.vue'
 
@@ -73,6 +74,12 @@ export default {
   mounted () {
 			document.addEventListener("keyup", this.keyup_handler, false);
       window.addEventListener('resize', this.resize_handler, false);
+      //Loading in the graf from cookies
+      cookieHelpers.checkRepCookie();
+      if(!cookieHelpers.isC) {
+        var d = grafhelpers.loadGraf(cookieHelpers.getCookie("GrafData"));
+        this.graf = d;
+      }
   },
   data () {
     return {
@@ -126,15 +133,21 @@ export default {
         this.graf.links = [];
         this.grafData = "";
         this.graf.aggCount = 1;
+      //Modifying cookie
+      cookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
     },
     onAlgorithmChange(alg) {
         this.selection.selectedAlgorithm = alg;
     },
     onUndo() {
         this.graf = helperFunctions.updateHistory(this.graf, this.history, true);
+        //Modifying cookie
+        cookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
     },
     onRedo() {
         this.graf = helperFunctions.updateHistory(this.graf, this.history, false);
+        //Modifying cookie
+        cookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
     },
     useTool(tool) {
       var oldData = JSON.stringify(this.graf);
@@ -160,6 +173,8 @@ export default {
         default:
           break;
       }
+      //Modifying cookie
+      cookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
 
       var newData = JSON.stringify(this.graf);
       if(oldData != newData) {

--- a/Vue/graf/src/components/Graf.vue
+++ b/Vue/graf/src/components/Graf.vue
@@ -60,7 +60,7 @@ import Toolbar from '../components/Toolbar.vue'
 import GrafTools from '../middleware/grafTools.js'
 import PathTools from '../middleware/pathTools.js'
 import helperFunctions from '../middleware/helperFunctions';
-import cookieHelpers from "..middleware/cookieHelper.js";
+import CookieHelpers from '../middleware/cookieHelper';
 //import Help from "../components/Help.vue";
 //import About from 'About.vue'
 
@@ -75,9 +75,9 @@ export default {
 			document.addEventListener("keyup", this.keyup_handler, false);
       window.addEventListener('resize', this.resize_handler, false);
       //Loading in the graf from cookies
-      cookieHelpers.checkRepCookie();
-      if(!cookieHelpers.isC) {
-        var d = grafhelpers.loadGraf(cookieHelpers.getCookie("GrafData"));
+      CookieHelpers.checkRepCookie();
+      if(!CookieHelpers.isC) {
+        var d = grafhelpers.loadGraf(CookieHelpers.getCookie("GrafData"));
         this.graf = d;
       }
   },
@@ -134,7 +134,7 @@ export default {
         this.grafData = "";
         this.graf.aggCount = 1;
       //Modifying cookie
-      cookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
+      CookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
     },
     onAlgorithmChange(alg) {
         this.selection.selectedAlgorithm = alg;
@@ -142,12 +142,12 @@ export default {
     onUndo() {
         this.graf = helperFunctions.updateHistory(this.graf, this.history, true);
         //Modifying cookie
-        cookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
+        CookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
     },
     onRedo() {
         this.graf = helperFunctions.updateHistory(this.graf, this.history, false);
         //Modifying cookie
-        cookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
+        CookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
     },
     useTool(tool) {
       var oldData = JSON.stringify(this.graf);
@@ -174,7 +174,7 @@ export default {
           break;
       }
       //Modifying cookie
-      cookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
+      CookieHelpers.putCookie("GrafData", JSON.stringify(this.graf));
 
       var newData = JSON.stringify(this.graf);
       if(oldData != newData) {

--- a/Vue/graf/src/middleware/cookieHelper.js
+++ b/Vue/graf/src/middleware/cookieHelper.js
@@ -1,0 +1,125 @@
+class CookieHelper {
+
+
+
+
+  // Get function to retrieve a field from cookies
+  // @param key: corresponding string from when the key was stored
+  // @return String: value corresponding to key
+  getCookie(key) {
+    var ind = this.findCookie(key);
+    var kEndIndex = document.cookie.indexOf(String.fromCharCode(165),ind);
+    var vEndIndex = document.cookie.indexOf(String.fromCharCode(163),kEndIndex);
+    var value = document.cookie.substring(kEndIndex + 1, vEndIndex);
+    return value;
+  }
+
+  // Put function to emplace or update a field in cookies
+  // @param key: String for later retrieval
+  // @param value: String value to be stored
+  // @return boolean if an old value has been written over
+  putCookie(key, value) {
+
+    // USES ASCII 165 (Yen symbol) as a delimeter between corresponding key & value
+    // String.fromCharCode(165)
+    // USES ASCII 163 (GBPound symbol) as a delimeter after value before next unrelated key
+    // String.fromCharCode(163)
+
+    var ind = this.findCookie(key);
+
+    
+    var kEndIndex = -1;
+    var vEndIndex = -1;
+    
+    var entryString = key + String.fromCharCode(165) + 
+                      value + String.fromCharCode(163);
+    if(ind == -1) {
+      // Add the new key,value to the end of document.cookie
+      document.cookie += entryString;
+      return false;
+    }
+    kEndIndex = document.cookie.indexOf(String.fromCharCode(165), ind);
+    vEndIndex = document.cookie.indexOf(String.fromCharCode(163), kEndIndex);
+    
+    var oldVal = document.cookie.substring(ind+1,vEndIndex+1);
+    document.cookie = document.cookie.replace(oldVal,entryString);
+
+    this.checkRepCookie();
+    return true;
+    
+
+  }
+
+  // Gives the index in the cookie string where the pre-key delimiter is located
+  // @param key: String key to look up in cookie
+  // @return int index of ASCII 163 before key in cookie, -1 if not found
+  findCookie(key) {
+    var s = String.fromCharCode(163) + key;
+    var index = document.cookie.indexOf(s);
+    return index;
+  }
+  // Query for if a given cookie exists
+  // @param String 
+  // @return boolean 
+  isCookie(key) {
+    return this.findCookie(key) != -1;
+  }
+
+  // Query for if the cookies are empty
+  // @return boolean 
+  isCookieEmpty() {
+      return document.cookie == String.fromCharCode(163);
+  }
+
+
+  // Checks that the format of the cookies is valid. 
+  // If the checks fail, the cookies string is set to GBPound symbol
+  checkRepCookie() {
+    var ind1 = 0;
+    var ind2 = 0;
+    var ind3 = 0;
+    var isGood = true;
+
+    var keySet = new Set();
+    while(isGood) {
+      ind2 = document.cookie.indexOf(String.fromCharCode(165), ind1);
+
+      var k = document.cookie.substring(ind1+1,ind2);
+      if(keySet.has(k)) {
+        isGood = false;
+        break;
+      }
+      keySet.add(k);
+
+      ind3 = document.cookie.indexOf(String.fromCharCode(163), ind2);
+
+      ind1 = ind3;
+
+      if(ind1 == -1) {
+        isGood = false;
+        break;
+      } else if(ind1 == document.cookie.length-1) {
+        if(document.cookie.charAt(ind1) != String.fromCharCode(163)) {
+          isGood = false;
+          break;
+        } else {
+          isGood = true;
+          break;
+        }
+      }
+      
+    }
+    if(!isGood) {
+      console.log("BAD COOKIE CHECK REP\n\n" + document.cookie);
+      document.cookie = String.fromCharCode(163);
+      console.log("NewBlankCookie: " + document.cookie);
+      return;
+    }
+
+  }
+
+
+
+}
+
+export default new CookieHelper();

--- a/Vue/graf/src/middleware/grafTools.js
+++ b/Vue/graf/src/middleware/grafTools.js
@@ -1,6 +1,6 @@
 import PathTools from '../middleware/pathTools';
 import grafhelpers from '../middleware/helperFunctions';
-import cookieHelpers from '..middleware/cookieHelper.js';
+import cookieHelpers from '../middleware/cookieHelper';
 
 class GrafTools {
 

--- a/Vue/graf/src/middleware/grafTools.js
+++ b/Vue/graf/src/middleware/grafTools.js
@@ -1,5 +1,6 @@
-import PathTools from '../middleware/pathTools'
+import PathTools from '../middleware/pathTools';
 import grafhelpers from '../middleware/helperFunctions';
+import cookieHelpers from '..middleware/cookieHelper.js';
 
 class GrafTools {
 
@@ -29,6 +30,8 @@ class GrafTools {
             grafhelpers.color_graf(graf, 'red', 'edge', new Set([selected]));
         selection.selectedEdges.add(selected);
     }
+    //Modifying cookie
+    cookieHelpers.putCookie("GrafData", JSON.stringify(graf));
   }
 
   new_node(graf) {
@@ -155,6 +158,7 @@ class GrafTools {
     }
     return childIds;
   }
+
 }
 
 export default new GrafTools();


### PR DESCRIPTION
Added functionality to save the current graf in cookies.  

The module "cookieHelper.js" can be used by anyone to add their own data field to the cookies string with (key,value) pairs.  The interface is very easy to use (put & get) and hopefully is useful to people in the future.  

There is a significant amount of comments and documentation at the beginning of each function.  

NOTE: do not try to store anything using the symbols "£" or "¥" as a key or a value in the cookies, they are used as delimiters within the cookies string

