### PR TITLE
Max/clear select

### DIFF
--- a/Vue/graf/src/App.vue
+++ b/Vue/graf/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" v-on:mousemove="sideBarCheck">
+  <div id="app">
     <Settings v-bind:open="Toggled"/>
     <div id="Router">
       <router-view/>
@@ -8,24 +8,13 @@
 </template>
 
 <script>
-import Settings from './components/Settings.vue';
+
 
 export default {
   name: 'App',
-  components: { Settings },
+  components: {},
   data() { return { Toggled: false, } },
   methods: {
-    sideBarCheck: function(event) {
-      var x = event.clientX;
-      var y = event.clientY;
-      if(x < 200 && y < 50) {
-        this.Toggled = true;
-      } else if (x < 200 && this.Toggled) {
-        this.Toggled = true;
-      } else {
-        this.Toggled = false;
-      }
-    }
   }
 }
 </script>

--- a/Vue/graf/src/components/Graf.vue
+++ b/Vue/graf/src/components/Graf.vue
@@ -5,9 +5,9 @@
       <header class="fixedTC">
         <Toolbar @tool-change="change_tool" @edge-change="change_edge" @alg-change="onAlgorithmChange"></Toolbar>
 
-        <sui-button @click="onUndo();" icon="undo" />
-        <sui-button @click="onRedo();" icon="redo" />
-        <sui-button @click="clear_selections()" @ icon ="eye slash"/>
+        <sui-button @click="onUndo();" icon="undo" data-tooltip="Ctrl-Z" data-position="bottom center"/>
+        <sui-button @click="onRedo();" icon="redo" data-tooltip="Ctrl-Y" data-position="bottom center"/>
+        <sui-button @click="clear_selections()" icon ="eye slash" data-tooltip="Esc" data-position="bottom center"/>
         <InfoBox v-if="selection.selectedNodes.size || selection.selectedEdges.size" v-bind:selected="selection"> </InfoBox>
 
         <div class="labeler"  v-if="currentTool=='Label' && selection.selectedLabel"

--- a/Vue/graf/src/components/Graf.vue
+++ b/Vue/graf/src/components/Graf.vue
@@ -7,6 +7,7 @@
 
         <sui-button @click="onUndo();" icon="undo" />
         <sui-button @click="onRedo();" icon="redo" />
+        <sui-button @click="clear_selections()" @ icon ="eye slash"/>
         <InfoBox v-if="selection.selectedNodes.size || selection.selectedEdges.size" v-bind:selected="selection"> </InfoBox>
 
         <div class="labeler"  v-if="currentTool=='Label' && selection.selectedLabel"
@@ -196,6 +197,8 @@ export default {
       this.options.linkWidth = 3;
       this.options = Object.assign({},this.options)
       this.$root.$emit('resetSliders')
+      this.selection.selectedNodes = new Set();
+      this.selection.selectedEdges = new Set();
       //Modifying cookie
       var s = CookieHelpers.compressGraf(JSON.stringify(this.graf));
       CookieHelpers.putCookie("GrafData", s);
@@ -283,11 +286,12 @@ export default {
     change_edge (edgeType) {
       this.edgeType = edgeType;
     },
-    keyup_handler(event) {
-      if (event.code == "Escape") {
+    clear_selections(){
         PathTools.update_distances(this.graf, null, false);
         GrafTools.clear_selection(this.graf, this.selection);
-      }
+    },
+    keyup_handler(event) {
+      if (event.code == "Escape") {this.clear_selections()}
       if (event.ctrlKey && event.code === "KeyZ") this.onUndo();
       if (event.ctrlKey && event.code === "KeyY") this.onRedo();
     },


### PR DESCRIPTION
The graf now correctly resets selections on reset(Issue 80)
There is now a good clear selections button next to the undo and redo with a popup to tell you esc is the hotkey(Issue 75)